### PR TITLE
Allow a granular fallback to external configuration

### DIFF
--- a/src/main/scala/TestHttp.scala
+++ b/src/main/scala/TestHttp.scala
@@ -22,7 +22,7 @@ object TestHttp extends App{
       override implicit def actorRefFactory: ActorRefFactory = system
     }
     val url = "https://httpbin.org/delay/10" // "http://127.0.0.1:8081/"
-    val conf = RequestConfiguration(requestTimeout = Duration(12, TimeUnit.SECONDS), idleTimeout = Duration(5, TimeUnit.SECONDS))
+    val conf = RequestConfiguration(requestTimeout = Option(Duration(12, TimeUnit.SECONDS)), idleTimeout = Option(Duration(5, TimeUnit.SECONDS)))
     implicit val reporter = NoOpReporter
     implicit val timeout = Timeout(30, TimeUnit.SECONDS)
 
@@ -36,7 +36,7 @@ object TestHttp extends App{
     }
 
     //Should time out and keep retrying
-    val tightConf = conf.copy(requestTimeout = Duration(3, TimeUnit.SECONDS))
+    val tightConf = conf.copy(requestTimeout = Option(Duration(3, TimeUnit.SECONDS)))
     val request2 = client.makeRequest(Request(url, requestConfiguration = Option(tightConf)))
 
     request2.onComplete {

--- a/src/main/scala/ignition/core/http/AsyncHttpClientStreamApi.scala
+++ b/src/main/scala/ignition/core/http/AsyncHttpClientStreamApi.scala
@@ -26,19 +26,29 @@ object AsyncHttpClientStreamApi {
   // TODO: return a stream is dangerous because implies into a lock
   case class StreamResponse(status: Int, content: InputStream)
 
-  case class RequestConfiguration(maxRedirects: Int = 15,
-                                  maxConnectionsPerHost: Int = 500,
-                                  pipelining: Boolean = false,
-                                  idleTimeout: Duration = Duration(30, TimeUnit.SECONDS),
-                                  requestTimeout: Duration = Duration(20, TimeUnit.SECONDS),
-                                  connectingTimeout: Duration = Duration(10, TimeUnit.SECONDS))
+  // If any value is None, it will fallback to the implementation's default
+  object RequestConfiguration {
+    val defaultMaxRedirects: Int = 15
+    val defaultMaxConnectionsPerHost: Int = 500
+    val defaultPipelining: Boolean = false
+    val defaultIdleTimeout: FiniteDuration = Duration(30, TimeUnit.SECONDS)
+    val defaultRequestTimeout: FiniteDuration = Duration(20, TimeUnit.SECONDS)
+    val defaultConnectingTimeout: FiniteDuration = Duration(10, TimeUnit.SECONDS)
+  }
+
+  case class RequestConfiguration(maxRedirects: Option[Int] = Option(RequestConfiguration.defaultMaxRedirects),
+                                  maxConnectionsPerHost: Option[Int] = Option(RequestConfiguration.defaultMaxConnectionsPerHost),
+                                  pipelining: Option[Boolean] = Option(RequestConfiguration.defaultPipelining),
+                                  idleTimeout: Option[Duration] = Option(RequestConfiguration.defaultIdleTimeout),
+                                  requestTimeout: Option[Duration] = Option(RequestConfiguration.defaultRequestTimeout),
+                                  connectingTimeout: Option[Duration] = Option(RequestConfiguration.defaultConnectingTimeout))
 
   case class Request(url: String,
                      params: Map[String, String] = Map.empty,
                      credentials: Option[Credentials] = None,
                      method: HttpMethod = HttpMethods.GET,
                      body: HttpEntity = HttpEntity.Empty,
-                     requestConfiguration: Option[RequestConfiguration] = Option(RequestConfiguration()))
+                     requestConfiguration: Option[RequestConfiguration] = None)
 
   case class RequestException(message: String, response: StreamResponse) extends RuntimeException(message)
 


### PR DESCRIPTION
Also always use our host setup to avoid misconfiguration on important settings.