### PR TITLE
Fix/destroy function

### DIFF
--- a/tools/cluster.py
+++ b/tools/cluster.py
@@ -14,7 +14,7 @@ from argh.decorators import named, arg
 import subprocess
 from subprocess import check_output, check_call
 from utils import tag_instances, get_masters, get_active_nodes, get_active_nodes_by_tag
-from utils import check_call_with_timeout, check_call_with_timeout_describe, destroy_by_request_spot_ids
+from utils import check_call_with_timeout, check_call_with_timeout_describe, destroy_by_fleet_id
 import os
 import sys
 from datetime import datetime
@@ -383,10 +383,10 @@ def destroy(cluster_name, wait_termination=False, vpc=default_vpc, wait_timeout_
     
     try: # First we test if exist the cluster with the function cluster_exists        
         # get instances ids by json return and cancel the requests
-        wait_for_intances_to_terminate(cluster_name, wait_termination, wait_timeout_minutes, destroy_by_request_spot_ids(region, cluster_name))
+        wait_for_intances_to_terminate(cluster_name, wait_termination, wait_timeout_minutes, destroy_by_fleet_id(region, cluster_name))
         
         # test if the cluster exists and call destroy by fintorock to destroy it
-        if(destroy_by_flyntrock(region, cluster_name, vpc, script_timeout_total_minutes, script_timeout_inactivity_minutes, wait_termination, wait_timeout_minutes)):
+        if destroy_by_flyntrock(region, cluster_name, vpc, script_timeout_total_minutes, script_timeout_inactivity_minutes, wait_termination, wait_timeout_minutes):
             # Here we use the script to destroy the cluster using the name of it
             all_instances = masters + slaves
             # To better view about what the script is doing i choose to let the same code of the destroy i have updated

--- a/tools/delete_fleet.py
+++ b/tools/delete_fleet.py
@@ -1,0 +1,46 @@
+import sys
+from time import sleep
+
+import boto3
+from botocore.exceptions import ClientError
+
+def describe_fleets(region, fleet_id):
+    ec2 = boto3.client('ec2', region_name=region)
+    response = ec2.describe_fleets(
+       FleetIds=[
+            fleet_id
+        ],
+    )
+
+    return response['Fleets'][0]['Instances'][0]['InstanceIds']
+
+def delete_fleet(region, fleet_id):
+    ec2 = boto3.client('ec2', region_name=region)
+    response = ec2.delete_fleets(
+        FleetIds=[
+            fleet_id,
+        ],
+        TerminateInstances=True
+    )
+
+    return response['SuccessfulFleetDeletions'][0]['CurrentFleetState']
+
+
+if __name__ == '__main__':
+    region = sys.argv[1]
+    fleet_id = sys.argv[2]
+    try:
+        # Delete the fleet
+        fleet_deleted_states = ["deleted", "deleted_running", "deleted_terminating"]
+        fleet_state = None
+        while fleet_state not in fleet_deleted_states:
+            sleep(5)
+            fleet_state = delete_fleet(region=region, fleet_id=fleet_id)
+        print(f"Fleet deleted. Fleet state: {fleet_state}")
+
+        # get the instance ids from the fleet
+        print(describe_fleets(region=region, fleet_id=fleet_id))
+    except (ClientError, Exception) as e:
+        print(e)
+  
+  


### PR DESCRIPTION
## Problema/Motivação
Foi criado uma função para destruir os cluster criados pelo flintrock, por meio das _SpotInstanceRequestId_, o que funcionava bem antes da recente alteração para criação de cluster via create fleet, que gera o _FleetId_.

## O que foi feito
A lógica da função foi adaptada para destruir o cluster com o _FleetId_. 

## Como testar
+ Passe essa variável de ambiente para o Makefile que roda o cluster no dockerfile: 
```-e LOG_FOLDER="/app/mail-ignition/core/tools" ```

+ Use esse PR do flintrock, para poder funcionar a nova função: https://github.com/chaordic/flintrock/pull/16

+ Essa variável é necessária também em ambiente de produção, para o correto funcionamento dessa implementação, o caminho pode ser customizado.