### PR TITLE
removed javaagent parameter

### DIFF
--- a/remote_hook.sh
+++ b/remote_hook.sh
@@ -126,7 +126,7 @@ elif [[ "${JOB_NAME}" == "jupyter" ]]; then
 else
     JOB_OUTPUT="${JOB_CONTROL_DIR}/output.log"
     tail -F "${JOB_OUTPUT}" &
-    ${SPARK_HOME}/bin/spark-submit --master "${JOB_MASTER}" --driver-memory "${DRIVER_HEAP_SIZE}" --driver-java-options "-Djava.io.tmpdir=/media/tmp -verbose:gc -XX:-PrintGCDetails -XX:+PrintGCTimeStamps " --conf "spark.driver.extraJavaOptions=-javaagent:/tmp/jmx/jmx_prometheus_javaagent-0.17.0.jar=9095:/tmp/jmx/spark.yml" --class "${MAIN_CLASS}" ${JAR_PATH} "${JOB_NAME}" --runner-date "${JOB_DATE}" --runner-tag "${JOB_TAG}" --runner-user "${JOB_USER}" --runner-master "${JOB_MASTER}" --runner-executor-memory "${SPARK_MEM_PARAM}" "$@" >& "${JOB_OUTPUT}" || notify_error_and_exit "Execution failed for job ${JOB_WITH_TAG}"
+    ${SPARK_HOME}/bin/spark-submit --master "${JOB_MASTER}" --driver-memory "${DRIVER_HEAP_SIZE}" --driver-java-options "-Djava.io.tmpdir=/media/tmp -verbose:gc -XX:-PrintGCDetails -XX:+PrintGCTimeStamps " --class "${MAIN_CLASS}" ${JAR_PATH} "${JOB_NAME}" --runner-date "${JOB_DATE}" --runner-tag "${JOB_TAG}" --runner-user "${JOB_USER}" --runner-master "${JOB_MASTER}" --runner-executor-memory "${SPARK_MEM_PARAM}" "$@" >& "${JOB_OUTPUT}" || notify_error_and_exit "Execution failed for job ${JOB_WITH_TAG}"
 fi
 
 touch "${JOB_CONTROL_DIR}/SUCCESS"


### PR DESCRIPTION
Problema/Motivação
Configuração do Spark para que o Prometheus colete maior número de métricas.

O que foi feito
Modificada a linha de comando que executa o Job (spark-submit) removendo o parâmetro javaagent pois a partir de agora as métricas serão expostas pelo httpserver.

Como testar
-Atualizar o submódulo CORE do mail-ignition para a branch do PR (feat/prometheus-script)
-Através do run test-cluster
make image-bash
export AWS_ACCESS_KEY_ID="****"
export AWS_SECRET_ACCESS_KEY="****"
/app/mail-devops/deploy/roles/mail-ignition/files/scripts/job_runner.py run test-cluster /tmp